### PR TITLE
refactor: Notification 엔티티 ULID 적용

### DIFF
--- a/src/main/java/deepdive/jsonstore/domain/notification/controller/NotificationApiController.java
+++ b/src/main/java/deepdive/jsonstore/domain/notification/controller/NotificationApiController.java
@@ -56,4 +56,12 @@ public class NotificationApiController {
         List<NotificationHistoryResponse> history = notificationService.getNotificationHistory(memberUid);
         return ResponseEntity.ok(history);
     }
+
+    @GetMapping("/notificationsV2")
+    public ResponseEntity<List<NotificationHistoryResponse>> getNotificationHistoryV2(
+            @AuthenticationPrincipal(expression = "uid") UUID memberUid
+    ) {
+        List<NotificationHistoryResponse> history = notificationService.getNotificationHistoryV2(memberUid);
+        return ResponseEntity.ok(history);
+    }
 }

--- a/src/main/java/deepdive/jsonstore/domain/notification/controller/NotificationApiController.java
+++ b/src/main/java/deepdive/jsonstore/domain/notification/controller/NotificationApiController.java
@@ -59,9 +59,9 @@ public class NotificationApiController {
 
     @GetMapping("/notificationsV2")
     public ResponseEntity<List<NotificationHistoryResponse>> getNotificationHistoryV2(
-            @AuthenticationPrincipal(expression = "uid") UUID memberUid
+            @AuthenticationPrincipal(expression = "ulid") byte[] ulid
     ) {
-        List<NotificationHistoryResponse> history = notificationService.getNotificationHistoryV2(memberUid);
+        List<NotificationHistoryResponse> history = notificationService.getNotificationHistoryV2(ulid);
         return ResponseEntity.ok(history);
     }
 }

--- a/src/main/java/deepdive/jsonstore/domain/notification/entity/Notification.java
+++ b/src/main/java/deepdive/jsonstore/domain/notification/entity/Notification.java
@@ -1,6 +1,7 @@
 package deepdive.jsonstore.domain.notification.entity;
 
 import deepdive.jsonstore.common.entity.BaseEntity;
+import deepdive.jsonstore.common.util.UlidUtil;
 import deepdive.jsonstore.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
@@ -17,6 +18,9 @@ public class Notification extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name = "ulid", columnDefinition = "BINARY(16)", nullable = false, unique = true)
+    private byte[] ulid;
 
     @Column(nullable = false, length = 255)
     private String title;
@@ -35,4 +39,8 @@ public class Notification extends BaseEntity {
             foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)
     )
     private Member member;
+
+    public void generateUlid() {
+        this.ulid = UlidUtil.createUlidBytes();
+    }
 }

--- a/src/main/java/deepdive/jsonstore/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/deepdive/jsonstore/domain/notification/repository/NotificationRepository.java
@@ -15,5 +15,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @EntityGraph(attributePaths = {"member"})
     List<Notification> findByMember_UidOrderByCreatedAtDesc(UUID memberUid);
 
-    List<Notification> findAllByMember_UidOrderByUlidDesc(UUID memberUid);
+    @EntityGraph(attributePaths = {"member"})
+    List<Notification> findAllByMember_UlidOrderByUlidDesc(byte[] ulid);
 }

--- a/src/main/java/deepdive/jsonstore/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/deepdive/jsonstore/domain/notification/repository/NotificationRepository.java
@@ -14,4 +14,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     // UUID 기반 조회로 변경
     @EntityGraph(attributePaths = {"member"})
     List<Notification> findByMember_UidOrderByCreatedAtDesc(UUID memberUid);
+
+    List<Notification> findAllByMember_UidOrderByUlidDesc(UUID memberUid);
 }

--- a/src/main/java/deepdive/jsonstore/domain/notification/service/NotificationService.java
+++ b/src/main/java/deepdive/jsonstore/domain/notification/service/NotificationService.java
@@ -6,6 +6,7 @@ import com.google.firebase.messaging.WebpushConfig;
 import com.google.firebase.messaging.WebpushNotification;
 import deepdive.jsonstore.common.exception.JsonStoreErrorCode;
 import deepdive.jsonstore.common.exception.CommonException;
+import deepdive.jsonstore.common.util.UlidUtil;
 import deepdive.jsonstore.domain.member.entity.Member;
 import deepdive.jsonstore.domain.member.repository.MemberRepository;
 import deepdive.jsonstore.domain.notification.dto.NotificationHistoryResponse;
@@ -97,8 +98,8 @@ public class NotificationService {
                 .collect(Collectors.toList());
     }
 
-    public List<NotificationHistoryResponse> getNotificationHistoryV2(UUID memberUid) {
-        return notificationRepository.findAllByMember_UidOrderByUlidDesc(memberUid).stream()
+    public List<NotificationHistoryResponse> getNotificationHistoryV2(byte[] ulid) {
+        return notificationRepository.findAllByMember_UlidOrderByUlidDesc(ulid).stream()
                 .map(notification -> new NotificationHistoryResponse(
                         notification.getId(),
                         notification.getTitle(),

--- a/src/main/java/deepdive/jsonstore/domain/notification/service/NotificationService.java
+++ b/src/main/java/deepdive/jsonstore/domain/notification/service/NotificationService.java
@@ -78,6 +78,8 @@ public class NotificationService {
                 .category(category)
                 .member(member)
                 .build();
+        // ✅ ULID 자동 생성
+        notification.generateUlid();
 
         notificationRepository.save(notification);
     }
@@ -94,4 +96,19 @@ public class NotificationService {
                 ))
                 .collect(Collectors.toList());
     }
+
+    public List<NotificationHistoryResponse> getNotificationHistoryV2(UUID memberUid) {
+        return notificationRepository.findAllByMember_UidOrderByUlidDesc(memberUid).stream()
+                .map(notification -> new NotificationHistoryResponse(
+                        notification.getId(),
+                        notification.getTitle(),
+                        notification.getBody(),
+                        notification.getCategory(),
+                        notification.getMember().getUid(),
+                        notification.getCreatedAt()
+                ))
+                .collect(Collectors.toList());
+    }
+
+
 }

--- a/src/main/resources/static/firebase-messaging-sw.js
+++ b/src/main/resources/static/firebase-messaging-sw.js
@@ -12,7 +12,7 @@ const firebaseConfig = {
 };
 
 const messaging = firebase.messaging();
-
+firebase.analytics();
 messaging.onBackgroundMessage((payload) => {
     console.log('[firebase-messaging-sw.js] 백그라운드 메시지 수신:', payload);
     const notificationTitle = payload.notification.title;

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -136,7 +136,7 @@
 
         const registration = await navigator.serviceWorker.ready;
         const fcmToken = await firebase.messaging().getToken({
-          vapidKey: "BFb0x3jt3JOK6l0eG7iBXKyiiZszUCINd4NgNRqDYNGPM3-Uny9Dch6z7e_Ac2lwUjiJR8MMSP4V2Oxv_LKaSFA",
+          vapidKey: "BMudtW8mJr24K2EAYNoi2-8G_KYrTgRVWt93aQyYthGuaFEIWWcf1uU7D4s-FxCEWmlTCJJBlgrEHmRl7y8fCUI",
           serviceWorkerRegistration: registration,
         });
 

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -35,6 +35,10 @@
     <p id="tokenStatus"></p>
   </div>
 
+  <input type="file" id="tokenFile" accept=".json" />
+  <button id="registerAllButton">더미 유저 저장</button>
+  <pre id="bulkTokenStatus"></pre>
+
   <!-- 알림 테스트 -->
   <div class="card">
     <h2>2. 알림 테스트</h2>
@@ -103,6 +107,62 @@
     });
   }
 </script>
+<script>
+  let jwtList = [];
+
+  // 파일 업로드 후 JWT 파싱
+  document.getElementById('tokenFile').addEventListener('change', async (e) => {
+    const file = e.target.files[0];
+    const text = await file.text();
+    const json = JSON.parse(text);
+    jwtList = json.map(row => row.accessToken);
+    document.getElementById('bulkTokenStatus').textContent = `📦 ${jwtList.length}개의 JWT 토큰 로드 완료`;
+  });
+
+  // 일괄 등록 버튼 클릭 시 실행
+  document.getElementById('registerAllButton').addEventListener('click', async () => {
+    const status = document.getElementById('bulkTokenStatus');
+    status.textContent = '🚀 일괄 토큰 등록 시작...';
+    const results = [];
+
+    for (let i = 0; i < jwtList.length; i++) {
+      const jwt = jwtList[i];
+      try {
+        const permission = await Notification.requestPermission();
+        if (permission !== 'granted') {
+          results.push(`❌ ${i + 1}: 알림 권한 거부`);
+          continue;
+        }
+
+        const registration = await navigator.serviceWorker.ready;
+        const fcmToken = await firebase.messaging().getToken({
+          vapidKey: "BFb0x3jt3JOK6l0eG7iBXKyiiZszUCINd4NgNRqDYNGPM3-Uny9Dch6z7e_Ac2lwUjiJR8MMSP4V2Oxv_LKaSFA",
+          serviceWorkerRegistration: registration,
+        });
+
+        const res = await fetch('/api/v1/fcm-tokens', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${jwt}`
+          },
+          body: JSON.stringify({ token: fcmToken }),
+        });
+
+        if (res.ok) {
+          results.push(`✅ ${i + 1}: 등록 성공`);
+        } else {
+          results.push(`❌ ${i + 1}: 실패 - ${await res.text()}`);
+        }
+      } catch (err) {
+        results.push(`❌ ${i + 1}: 오류 - ${err.message}`);
+      }
+    }
+
+    status.textContent = `📦 등록 결과\n${results.join('\n')}`;
+  });
+</script>
+
 
 </body>
 </html>

--- a/src/main/resources/static/js/firebase-init.js
+++ b/src/main/resources/static/js/firebase-init.js
@@ -8,6 +8,7 @@ const firebaseConfig = {
   measurementId: "G-4MW54E47HT"
 };
 
+firebase.analytics();
 firebase.initializeApp(firebaseConfig);
 firebase.auth().signInAnonymously().then(() => {
   console.log("익명 로그인 성공");

--- a/src/main/resources/static/js/register-token.js
+++ b/src/main/resources/static/js/register-token.js
@@ -16,7 +16,7 @@ document.getElementById('registerButton').addEventListener('click', async () => 
 
     const registration = await navigator.serviceWorker.register('/firebase-messaging-sw.js');
     const token = await messaging.getToken({
-      vapidKey: "BFb0x3jt3JOK6l0eG7iBXKyiiZszUCINd4NgNRqDYNGPM3-Uny9Dch6z7e_Ac2lwUjiJR8MMSP4V2Oxv_LKaSFA",
+      vapidKey: "BMudtW8mJr24K2EAYNoi2-8G_KYrTgRVWt93aQyYthGuaFEIWWcf1uU7D4s-FxCEWmlTCJJBlgrEHmRl7y8fCUI",
       serviceWorkerRegistration: registration,
     });
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

26-refactor-알림내역-조회-ulid-적용

## 📝 작업 내용

ULID 적용 전 조회 성능 테스트 완
ULID 적용 후 조회 성능 테스트 완
V2버전 컨트롤러 서비스단 추가
ULID DESC(최신순) 으로 조회하는 JPA 메소드 추가
MemberULID 적용

result: 알림내역 조회 및 최신순 정렬시간 단축

![스크린샷 2025-04-22 오후 9 06 53](https://github.com/user-attachments/assets/d1943ac3-9216-4fac-98c6-7ee86bff46d7)
![스크린샷 2025-04-22 오후 11 08 55](https://github.com/user-attachments/assets/58a3b5e2-7eed-4547-bebd-164035911aff)

- 내부 정렬 기준을 `ulid` 기준으로 최적화
- 성능 지표 모두 소폭 개선되었으며, 특히 p99가 40 → 30ms로 줄어듬.
- 401 에러는 인증 토큰 누락 또는 만료 가능성이 있는 개별 유저 문제로 보이며, 시스템적 성능 문제는 아님.
- Member ULID를 Param으로 요청하는 버전으로 테스트 재진행 필요 (Member 도메인 V2 리팩토링 완료 후)

### MemberULID 적용  (4/23)
- memberULID 적용 전
![스크린샷 2025-04-23 오후 6 53 57](https://github.com/user-attachments/assets/b0a643e6-e0ad-44cf-9da1-9ab2c6407aff)

- memberULID 적용 후
![스크린샷 2025-04-23 오후 6 57 27](https://github.com/user-attachments/assets/5bd876c4-669b-45c1-bfa5-fd32f6f6ad1e)

1. 응답 속도  
평균 응답 속도 및 P50, P95는 동일함 (8ms / 12ms)
최대 응답 시간은 70ms → 45ms로 개선
→ 긴 tail 요청이 줄어든 것으로 해석 가능

2. 오류 수 (401)  
13건 → 8건으로 감소  
직접적인 인덱스 영향은 아닐 수 있지만, 전체 시스템 응답이 더 안정적이라는 간접적 힌트  

3. 응답 분포 안정성  
인덱싱 후에도 P99에서 약간의 16ms 상승이 있으나, 전체적으로 긴 요청 tail이 줄어듦  