### PR TITLE
chore: prometheus 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,10 @@ dependencies {
 
     // ULID
     implementation("de.huxhorn.sulky:de.huxhorn.sulky.ulid:8.3.0")
+
+    //Metric
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/src/main/java/deepdive/jsonstore/common/config/SecurityConfig.java
+++ b/src/main/java/deepdive/jsonstore/common/config/SecurityConfig.java
@@ -109,6 +109,7 @@ public class SecurityConfig {
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/actuator/prometheus").permitAll()
                         // 공용
                         .requestMatchers(
                                 "/", "/index.html", "/css/**", "/js/**", "/firebase-messaging-sw.js",

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,3 +9,14 @@ spring:
     properties:
       hibernate:
         default_batch_fetch_size: 1000
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+  endpoint:
+    health:
+      show-details: always
+  security:
+    enabled: false  # actuator security 끄기


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#66 

## 📝 작업 내용

build.gradle - prometheus 의존성 라이브러리 추가.  
application.yml - Actuator + Prometheus 엔드포인트 노출 설정 추가    
SecurityConfig.java - /actuator/prometheus 경로 permitAll 추가.  

메트릭 제공 엔드포인트 : http://localhost:8080/actuator/prometheus -> prometheus.yml 에서 설정,  .gitignore
1. Prometheus는 등록된 Target(서버) 들에 대해  
2. 정해진 주기마다   
3. HTTP GET 요청을 보내서   
4. 메트릭 텍스트 데이터를 긁어오고   
5. 자기 데이터베이스(TimeSeries DB)에 저장한다.   
6. Grafana는 저장된 데이터를 쿼리해서 그래프를 그림

### 스크린샷 (선택)
<테스트 그래프 결과>
![스크린샷 2025-04-28 오후 4 50 04](https://github.com/user-attachments/assets/d5e06205-1b49-4581-aedf-2eb82e2203a5)

