### PR TITLE
feat : 기본 전체 페이지 조회 캐싱

### DIFF
--- a/src/main/java/deepdive/jsonstore/domain/product/controller/ProductControllerV2.java
+++ b/src/main/java/deepdive/jsonstore/domain/product/controller/ProductControllerV2.java
@@ -48,6 +48,7 @@ public class ProductControllerV2 {
 	@GetMapping
 	public ResponseEntity<Page<ProductResponse>> getActiveProduct(ProductSearchCondition condition, Pageable pageable) {
 		log.info("condition: {}", condition);
+		log.info("pageable: {}", pageable);
 		Page<ProductResponse> res = productService.getProductList(condition, pageable);
 		log.info("res: {}", res);
 		return ResponseEntity.ok(res);

--- a/src/main/java/deepdive/jsonstore/domain/product/dto/ProductCache.java
+++ b/src/main/java/deepdive/jsonstore/domain/product/dto/ProductCache.java
@@ -1,0 +1,13 @@
+package deepdive.jsonstore.domain.product.dto;
+
+import deepdive.jsonstore.domain.product.entity.ProductDocument;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ProductCache(
+        List<ProductResponse> content,
+        long totalElements
+) {
+}

--- a/src/main/java/deepdive/jsonstore/domain/product/dto/ProductSearchCondition.java
+++ b/src/main/java/deepdive/jsonstore/domain/product/dto/ProductSearchCondition.java
@@ -9,4 +9,7 @@ public record ProductSearchCondition(
 	ProductSortType sort,
 	String search
 ) {
+	public boolean isEmpty() {
+		return this.category == null && this.sort == null && this.search == null;
+	}
 }

--- a/src/main/java/deepdive/jsonstore/domain/product/service/ProductServiceV2.java
+++ b/src/main/java/deepdive/jsonstore/domain/product/service/ProductServiceV2.java
@@ -1,22 +1,22 @@
 package deepdive.jsonstore.domain.product.service;
 
-import deepdive.jsonstore.domain.product.dto.ProductListResponse;
+import deepdive.jsonstore.domain.product.dto.ProductCache;
 import deepdive.jsonstore.domain.product.dto.ProductResponse;
 import deepdive.jsonstore.domain.product.dto.ProductSearchCondition;
 import deepdive.jsonstore.domain.product.entity.Product;
 import deepdive.jsonstore.domain.product.entity.ProductDocument;
 import deepdive.jsonstore.domain.product.repository.ProductEsRepository;
-import deepdive.jsonstore.domain.product.repository.ProductQueryRepository;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.UUID;
+import java.time.Duration;
 
 @Slf4j
 @Service
@@ -27,6 +27,10 @@ public class ProductServiceV2 {
 	private final ProductValidationServiceV2 productValidationService;
 	private final ProductEsRepository productEsRepository;
     private final MeterRegistry meterRegistry;
+	private final RedisTemplate<String, Object> redisTemplate;
+	private static final String CACHE_KEY = "productPage:";
+	private static final long TTL = 5;
+
 	public ProductResponse getActiveProductDetail(String id) {
 		Product product = productValidationService.findActiveProductById(id);
 		meterRegistry.counter("business.product.viewed").increment();
@@ -35,9 +39,33 @@ public class ProductServiceV2 {
 	}
 
 	public Page<ProductResponse> getProductList(ProductSearchCondition condition, Pageable pageable) {
-		Page<ProductDocument> productDocuments = productEsRepository.searchByCategoryAndName(condition.category(),condition.search(), pageable);
-		Page<ProductResponse> res = productDocuments.map(ProductResponse::toProductResponse);
-		return res;
+		if (condition.isEmpty()
+				&& pageable.getSort().isUnsorted()
+				&& pageable.getPageNumber() == 0) {
+
+
+			ProductCache cached = (ProductCache) redisTemplate.opsForValue().get(CACHE_KEY);
+
+			if (cached != null) { // && !cached.content().isEmpty() 아예 상품이 없는 경우
+				log.info("from cache");
+				return new PageImpl<>(cached.content(), pageable, cached.totalElements());
+			}
+
+//			log.info("from All");
+			Page<ProductResponse> result = productEsRepository.findAll(pageable)
+					.map(ProductResponse::toProductResponse);
+
+			ProductCache cache = ProductCache.builder()
+					.content(result.getContent())
+					.totalElements(result.getTotalElements())
+					.build();
+
+			redisTemplate.opsForValue().set(CACHE_KEY, cache, Duration.ofMinutes(TTL));
+			return result;
+		}
+
+		Page<ProductDocument> productDocuments = productEsRepository.searchByCategoryAndName(condition.category(), condition.search(), pageable);
+		return productDocuments.map(ProductResponse::toProductResponse);
 	}
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

[89](https://github.com/json-store-25/json-store-be-fork/issues/89)

## 📝 작업 내용

- 전체 상품에 대해 캐싱했습니다.(카테고리x)
- JSON DSL로 컨디션이 null일때 전체조회 처리가 곤란해서 jpa findAll이 사용되었습니다.
- 카테고리랑 페이지도 조금만 수정하면 가능할 것 같습니다.
- 조회조합을 호출 레디스등에서 카운팅해서 어느정도 빈번한 요청이 있다면 캐싱하는 방법도 있을것같습니다.
- 부하테스트는 크게 의미가 없을 듯합니다.
- 더미데이터가 없어서 정확한 테스트가 아닙니다.

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/1ba646c4-aa33-4f6b-8d88-c992ef0458c0)

![image](https://github.com/user-attachments/assets/8b6d75bc-069f-42de-b09e-61b0c8ac24b8)


> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
